### PR TITLE
perf: optimize backend/frontend and add dashboard feature

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,33 +1,39 @@
 # Repository Guidelines
 
 ## Project Structure & Module Organization
+
 - `backend`: Rails 7 API with domain logic under `app/`, background jobs/Sidekiq config in `config/`, and API docs in `docs/`. Specs live in `spec/`, shared support in `spec/support/`.
 - `frontend`: Next.js 15 app in `src/` (UI under `src/app`, shared helpers in `src/lib`). Static assets live in `public/`.
 - `docs`: Additional reference docs; root `compose.yml` starts the full stack (frontend:3000, backend:3001, Postgres:5432, Redis:6379).
 
 ## Build, Test, and Development Commands
+
 - Start full stack: `docker compose up --build` (rebuilds frontend/backend images and runs Next dev + Rails server).
 - Backend DB prep: `docker compose exec backend bundle exec rails db:prepare` (setup or migrate).
 - Backend tests: `docker compose exec backend env RAILS_ENV=test bundle exec rspec` (SimpleCov via `COVERAGE=true`).
 - Backend lint: `docker compose exec backend bundle exec rubocop`.
-- Frontend dev only: `cd frontend && pnpm dev` (runs Turbopack at http://localhost:3000).
+- Frontend dev only: `cd frontend && pnpm dev` (runs Turbopack at <http://localhost:3000>).
 - Frontend lint/typecheck: `pnpm lint`, `pnpm typecheck`.
 - Frontend production build: `pnpm build`; start with `pnpm start`.
 
 ## Coding Style & Naming Conventions
+
 - Ruby: 2-space indent, follow RuboCop defaults; RSpec files as `*_spec.rb`. Prefer service objects and POROs under `app/` over fat controllers.
 - TypeScript/React: ESM with named exports; components in `src/app/**` use PascalCase folders/files. Keep shared utilities in `src/lib`.
 - Favor explicit types; avoid default exports unless a page or Next route requires it.
 
 ## Testing Guidelines
+
 - Backend uses RSpec; group examples with descriptive `context`/`it` blocks. Place shared helpers in `spec/support` and require via `.rspec`.
 - Aim for meaningful coverage; run `COVERAGE=true` locally to check reports at `backend/coverage/index.html`.
 - Frontend has no test harness yet—add Vitest/Testing Library co-located in `__tests__` near components when introducing tests.
 
 ## Commit & Pull Request Guidelines
+
 - Commit messages follow a light Conventional Commits style observed in history (e.g., `feat(mcp): …`, `fix: …`, `chore: …`, `style: …`). Keep scopes meaningful.
 - PRs should include: brief summary, test commands/results, linked issues, and UI screenshots for visible changes. Call out database migrations or breaking API changes explicitly.
 
 ## Security & Configuration
+
 - Keep secrets out of VCS; provide `RAILS_MASTER_KEY`, database credentials, and `SECRET_KEY_BASE` via environment or `.env` files ignored by git.
-- For local Docker runs, ensure Postgres/Redis ports are free to avoid container start failures.***
+- For local Docker runs, ensure Postgres/Redis ports are free to avoid container start failures.\*\*\*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,9 @@ docker compose build --no-cache frontend # If dependency issues persist
 docker compose exec frontend pnpm run lint        # ESLint
 docker compose exec frontend pnpm run lint:fix    # ESLint auto-fix
 docker compose exec frontend pnpm run typecheck   # TypeScript check
+docker compose exec frontend pnpm run test        # Vitest unit tests
+docker compose exec frontend pnpm run test:watch  # Vitest watch mode
+docker compose exec frontend pnpm run test:coverage # Vitest with coverage
 ```
 
 **開発中は `pnpm run build` を実行しない**（型チェックは `pnpm run typecheck` で行う）
@@ -71,6 +74,7 @@ docker compose exec backend bundle exec rubocop -A    # Auto-correct all
 ```bash
 docker compose exec frontend pnpm run lint
 docker compose exec frontend pnpm run typecheck
+docker compose exec frontend pnpm run test
 docker compose exec backend env RAILS_ENV=test bundle exec rspec
 docker compose exec backend bundle exec rubocop
 # E2E tests (optional locally, CI runs automatically)
@@ -184,6 +188,13 @@ ServerApiClient (lib/server/api-client.ts) ← Server Component用、cookies()�
 - `/api/v1/todos/:id/comments/*` - コメント（soft delete付き）
 - `/api/v1/todos/:id/histories` - 変更履歴
 
+### Frontend Unit Tests (Vitest)
+
+- **テスト配置**: 各ディレクトリの `__tests__/` フォルダ内（例: `src/lib/__tests__/utils.test.ts`）
+- **設定**: `vitest.config.ts`（jsdom環境、`@/*` パスエイリアス対応）
+- **セットアップ**: `src/test/setup.ts` で `next/navigation` をモック
+- **ライブラリ**: Testing Library（React, user-event）+ jest-dom matchers
+
 ## E2E Test Architecture
 
 ```
@@ -214,6 +225,15 @@ docker compose exec backend env PROFILE_FACTORIES=true RAILS_ENV=test bundle exe
 - **FactoryBot最適化**: `transient { skip_user { false } }` でアソシエーション作成スキップ、`sequence` でFaker回避
 - **Shared Examples**: `'requires authentication'`（401検証）、`'api responses'`（レスポンスヘッダー検証）
 - **テスト設定**: トランザクショナルfixtures、ActiveJob inline adapter（Redis不要）
+
+## CI Pipeline
+
+GitHub Actions (`test.yml`) で3ジョブ並列実行:
+
+- **backend-tests**: RSpec + RuboCop + カバレッジ（閾値: 90%）
+- **frontend-tests**: ESLint + TypeCheck + Vitest + Build
+- **e2e-tests**: Playwright（Chrome、`retries: 2`）
+- **concurrency**: 同一PRへの新pushで進行中のCIを自動キャンセル
 
 ## Development Guidelines
 

--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -14,6 +14,9 @@ gem 'puma', '>= 5.0'
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin Ajax possible
 gem 'rack-cors', '~> 3.0'
 
+# Rate limiting
+gem 'rack-attack', '~> 6.7'
+
 # Authentication
 gem 'devise', '~> 4.9'
 gem 'devise-jwt', '~> 0.12'

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -220,6 +220,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.1)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-cors (3.0.0)
       logger
       rack (>= 3.0.14)
@@ -383,6 +385,7 @@ DEPENDENCIES
   mcp (~> 0.4)
   pg (~> 1.1)
   puma (>= 5.0)
+  rack-attack (~> 6.7)
   rack-cors (~> 3.0)
   rails (~> 8.0.0)
   redis (>= 4.0.1)

--- a/backend/app/controllers/api/v1/dashboard_controller.rb
+++ b/backend/app/controllers/api/v1/dashboard_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Api
+  module V1
+    # Dashboard statistics endpoint
+    # Returns aggregated productivity data for the current user
+    class DashboardController < BaseController
+      def stats
+        service = DashboardStatsService.new(user: current_user)
+        render_json_response(data: service.call)
+      end
+    end
+  end
+end

--- a/backend/app/controllers/mcp_controller.rb
+++ b/backend/app/controllers/mcp_controller.rb
@@ -5,8 +5,7 @@ class McpController < ApplicationController
   skip_before_action :authenticate_user!
   before_action :verify_mcp_token
 
-  # TODO: 本番環境では環境変数から取得すること
-  MCP_TOKEN = 'your-secret-mcp-token-here'
+  MCP_TOKEN = ENV.fetch('MCP_TOKEN', 'your-secret-mcp-token-here')
 
   def handle
     # MCPサーバーインスタンスを作成

--- a/backend/app/jobs/image_variant_job.rb
+++ b/backend/app/jobs/image_variant_job.rb
@@ -1,0 +1,23 @@
+class ImageVariantJob < ApplicationJob
+  queue_as :default
+
+  VARIANTS = {
+    thumb: { resize_to_limit: [300, 300] },
+    medium: { resize_to_limit: [800, 800] }
+  }.freeze
+
+  def perform(blob_id)
+    blob = ActiveStorage::Blob.find_by(id: blob_id)
+    return unless blob&.image?
+
+    VARIANTS.each_value do |transformations|
+      blob.variant(transformations).processed
+    end
+  rescue ActiveStorage::FileNotFoundError,
+         ActiveStorage::InvariableError,
+         LoadError => e
+    Rails.logger.warn(
+      "ImageVariantJob failed for blob #{blob_id}: #{e.message}"
+    )
+  end
+end

--- a/backend/app/models/todo.rb
+++ b/backend/app/models/todo.rb
@@ -24,8 +24,8 @@ class Todo < ApplicationRecord
   before_create :set_position
   after_create :record_creation
   around_update :track_changes
-  after_save :invalidate_category_cache_if_changed
   after_destroy :invalidate_category_cache
+  after_save :invalidate_category_cache_if_changed
 
   private
 

--- a/backend/app/models/todo_tag.rb
+++ b/backend/app/models/todo_tag.rb
@@ -3,4 +3,14 @@ class TodoTag < ApplicationRecord
   belongs_to :tag
 
   validates :todo_id, uniqueness: { scope: :tag_id }
+
+  after_create :invalidate_tags_cache
+  after_destroy :invalidate_tags_cache
+
+  private
+
+  def invalidate_tags_cache
+    user_id = todo&.user_id
+    Rails.cache.delete("user_#{user_id}_tags") if user_id
+  end
 end

--- a/backend/app/services/dashboard_stats_service.rb
+++ b/backend/app/services/dashboard_stats_service.rb
@@ -93,20 +93,20 @@ class DashboardStatsService
     start_date = today - 6.days
 
     completed_by_day = TodoHistory
-      .unscope(:order)
-      .joins(:todo)
-      .where(todos: { user_id: user.id })
-      .where(
-        field_name: 'completed',
-        new_value: 'true'
-      )
-      .where(
-        todo_histories: {
-          created_at: start_date.beginning_of_day..today.end_of_day
-        }
-      )
-      .group("DATE(todo_histories.created_at)")
-      .count
+                       .unscope(:order)
+                       .joins(:todo)
+                       .where(todos: { user_id: user.id })
+                       .where(
+                         field_name: 'completed',
+                         new_value: 'true'
+                       )
+                       .where(
+                         todo_histories: {
+                           created_at: start_date.beginning_of_day..today.end_of_day
+                         }
+                       )
+                       .group('DATE(todo_histories.created_at)')
+                       .count
 
     (start_date..today).map do |date|
       {
@@ -122,21 +122,21 @@ class DashboardStatsService
     result = {}
     string_keys.each_with_index do |key, idx|
       result[key.to_sym] = counts.fetch(key, nil) ||
-                            counts.fetch(idx, 0)
+                           counts.fetch(idx, 0)
     end
     result
   end
 
   def sanitize_completion_sql(today, bow, bom)
     conn = ActiveRecord::Base.connection
-    date_fn = conn.adapter_name.match?(/SQLite/i) ? "DATE(updated_at)" : "updated_at::date"
+    date_fn = conn.adapter_name.match?(/SQLite/i) ? 'DATE(updated_at)' : 'updated_at::date'
 
     ActiveRecord::Base.sanitize_sql_array([
-      "COUNT(CASE WHEN #{date_fn} = ? THEN 1 END), " \
-        "COUNT(CASE WHEN #{date_fn} >= ? THEN 1 END), " \
-        "COUNT(CASE WHEN #{date_fn} >= ? THEN 1 END), " \
-        "COUNT(*)",
-      today, bow, bom
-    ])
+                                            "COUNT(CASE WHEN #{date_fn} = ? THEN 1 END), " \
+                                            "COUNT(CASE WHEN #{date_fn} >= ? THEN 1 END), " \
+                                            "COUNT(CASE WHEN #{date_fn} >= ? THEN 1 END), " \
+                                            'COUNT(*)',
+                                            today, bow, bom
+                                          ])
   end
 end

--- a/backend/app/services/dashboard_stats_service.rb
+++ b/backend/app/services/dashboard_stats_service.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+# Service to compute dashboard statistics for a user
+# Aggregates todo completion data, priority/status breakdowns,
+# category progress, and weekly trends
+class DashboardStatsService
+  attr_reader :user
+
+  def initialize(user:)
+    @user = user
+  end
+
+  def call
+    {
+      completion_stats: completion_stats,
+      priority_breakdown: priority_breakdown,
+      status_breakdown: status_breakdown,
+      category_progress: category_progress,
+      weekly_trend: weekly_trend
+    }
+  end
+
+  private
+
+  def todos
+    @todos ||= user.todos
+  end
+
+  # Single query using CASE WHEN to count completions
+  # for today, this week, and this month simultaneously
+  def completion_stats
+    today = Date.current
+    bow = today.beginning_of_week
+    bom = today.beginning_of_month
+
+    row = todos.where(completed: true).pick(
+      Arel.sql(sanitize_completion_sql(today, bow, bom))
+    )
+
+    today_count, week_count, month_count, total_completed =
+      row || [0, 0, 0, 0]
+
+    {
+      today: today_count,
+      this_week: week_count,
+      this_month: month_count,
+      total: todos.count,
+      total_completed: total_completed
+    }
+  end
+
+  def priority_breakdown
+    counts = todos.group(:priority).count
+    normalize_enum_counts(counts, %w[low medium high])
+  end
+
+  def status_breakdown
+    counts = todos.group(:status).count
+    normalize_enum_counts(counts, %w[pending in_progress completed])
+  end
+
+  # Uses GROUP BY aggregate query instead of loading
+  # all Todo objects into memory
+  def category_progress
+    totals = todos.where.not(category_id: nil)
+                  .group(:category_id)
+                  .count
+    completed_counts = todos.where(completed: true)
+                            .where.not(category_id: nil)
+                            .group(:category_id)
+                            .count
+
+    user.categories.map do |category|
+      total = totals.fetch(category.id, 0)
+      completed = completed_counts.fetch(category.id, 0)
+      pct = total.positive? ? (completed.to_f / total * 100).round(1) : 0.0
+
+      {
+        id: category.id,
+        name: category.name,
+        color: category.color,
+        total: total,
+        completed: completed,
+        progress: pct
+      }
+    end
+  end
+
+  # Joins TodoHistory through Todo to filter by
+  # todo owner (todos.user_id) rather than change author
+  def weekly_trend
+    today = Date.current
+    start_date = today - 6.days
+
+    completed_by_day = TodoHistory
+      .unscope(:order)
+      .joins(:todo)
+      .where(todos: { user_id: user.id })
+      .where(
+        field_name: 'completed',
+        new_value: 'true'
+      )
+      .where(
+        todo_histories: {
+          created_at: start_date.beginning_of_day..today.end_of_day
+        }
+      )
+      .group("DATE(todo_histories.created_at)")
+      .count
+
+    (start_date..today).map do |date|
+      {
+        date: date.iso8601,
+        count: completed_by_day.fetch(date, 0)
+      }
+    end
+  end
+
+  # Handles both string keys ('low') and integer keys (0)
+  # returned by Rails enum group queries
+  def normalize_enum_counts(counts, string_keys)
+    result = {}
+    string_keys.each_with_index do |key, idx|
+      result[key.to_sym] = counts.fetch(key, nil) ||
+                            counts.fetch(idx, 0)
+    end
+    result
+  end
+
+  def sanitize_completion_sql(today, bow, bom)
+    conn = ActiveRecord::Base.connection
+    date_fn = conn.adapter_name.match?(/SQLite/i) ? "DATE(updated_at)" : "updated_at::date"
+
+    ActiveRecord::Base.sanitize_sql_array([
+      "COUNT(CASE WHEN #{date_fn} = ? THEN 1 END), " \
+        "COUNT(CASE WHEN #{date_fn} >= ? THEN 1 END), " \
+        "COUNT(CASE WHEN #{date_fn} >= ? THEN 1 END), " \
+        "COUNT(*)",
+      today, bow, bom
+    ])
+  end
+end

--- a/backend/app/services/todo_search_service.rb
+++ b/backend/app/services/todo_search_service.rb
@@ -23,12 +23,16 @@ class TodoSearchService
   def apply_search(scope)
     return scope if search_query.blank?
 
-    search_term = "%#{search_query.downcase}%"
-
+    # ILIKE検索（pg_trgm GINインデックスで高速化、言語非依存）
+    ilike_query = "%#{sanitize_like(search_query)}%"
     scope.where(
-      'LOWER(todos.title) LIKE :query OR LOWER(todos.description) LIKE :query',
-      query: search_term
+      'todos.title ILIKE :q OR todos.description ILIKE :q',
+      q: ilike_query
     )
+  end
+
+  def sanitize_like(value)
+    value.to_s.gsub(/[%_\\]/) { |char| "\\#{char}" }
   end
 
   def search_query

--- a/backend/config/environments/development.rb
+++ b/backend/config/environments/development.rb
@@ -26,8 +26,11 @@ Rails.application.configure do
     config.action_controller.perform_caching = false
   end
 
-  # Change to :null_store to avoid any caching.
-  config.cache_store = :memory_store
+  # Redis cache store for development (categories/tags caching)
+  config.cache_store = :redis_cache_store, {
+    url: ENV.fetch("REDIS_URL", "redis://localhost:6379/0"),
+    expires_in: 5.minutes
+  }
 
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local

--- a/backend/config/environments/production.rb
+++ b/backend/config/environments/production.rb
@@ -43,8 +43,11 @@ Rails.application.configure do
   # Don't log any deprecations.
   config.active_support.report_deprecations = false
 
-  # Replace the default in-process memory cache store with a durable alternative.
-  # config.cache_store = :mem_cache_store
+  # Redis cache store for production (categories/tags caching, rate limiting)
+  config.cache_store = :redis_cache_store, {
+    url: ENV.fetch("REDIS_URL", "redis://localhost:6379/0"),
+    expires_in: 5.minutes
+  }
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
   # config.active_job.queue_adapter = :resque

--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -20,7 +20,8 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
   # MCP エンドポイント用のCORS設定
   # Claude DesktopなどのMCPクライアントからのアクセスを許可
   allow do
-    origins '*'
+    mcp_origins = ENV.fetch('MCP_ALLOWED_ORIGINS', 'http://localhost:3000').split(',').map(&:strip)
+    origins(*mcp_origins)
 
     resource '/mcp',
       headers: :any,

--- a/backend/config/initializers/rack_attack.rb
+++ b/backend/config/initializers/rack_attack.rb
@@ -1,0 +1,63 @@
+# Rate limiting configuration using Rack::Attack
+# Authenticated users: 100 requests/minute (per user)
+# Unauthenticated users: 20 requests/minute (per IP)
+
+# テスト環境ではデフォルトで無効化（テスト内で明示的に有効化可能）
+Rack::Attack.enabled = !Rails.env.test?
+
+Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new if Rails.env.test?
+Rack::Attack.cache.store = ActiveSupport::Cache::RedisCacheStore.new(
+  url: ENV.fetch('REDIS_URL', 'redis://localhost:6379/0')
+) unless Rails.env.test?
+
+# JWTからユーザーIDを抽出（BFFパターン対応）
+extract_user_id = lambda do |req|
+  token = req.env['HTTP_AUTHORIZATION']&.gsub(/^Bearer /, '')
+  return nil if token.blank?
+
+  secret = ENV['SECRET_KEY_BASE'] || Rails.application.credentials.secret_key_base
+  payload = JWT.decode(token, secret, true, algorithm: 'HS256').first
+  payload['sub']
+rescue JWT::DecodeError, JWT::ExpiredSignature
+  nil
+end
+
+# Authenticated users: 100 requests per minute (user ID単位)
+Rack::Attack.throttle('authenticated/user', limit: 100, period: 1.minute) do |req|
+  user_id = extract_user_id.call(req)
+  "user:#{user_id}" if user_id.present?
+end
+
+# Unauthenticated users: 20 requests per minute (IP単位)
+Rack::Attack.throttle('unauthenticated/ip', limit: 20, period: 1.minute) do |req|
+  token = req.env['HTTP_AUTHORIZATION']&.gsub(/^Bearer /, '')
+  req.ip if token.blank?
+end
+
+# Return 429 Too Many Requests with JSON body
+Rack::Attack.throttled_responder = lambda do |req|
+  match_data = req.env['rack.attack.match_data']
+  now = match_data[:epoch_time]
+
+  headers = {
+    'Content-Type' => 'application/json',
+    'Retry-After' => (match_data[:period] - (now % match_data[:period])).to_s,
+    'X-RateLimit-Limit' => match_data[:limit].to_s,
+    'X-RateLimit-Remaining' => '0',
+    'X-RateLimit-Reset' => (now + (match_data[:period] - (now % match_data[:period]))).to_s
+  }
+
+  body = {
+    error: {
+      code: 'RATE_LIMIT_EXCEEDED',
+      message: 'Rate limit exceeded. Please try again later.',
+      details: {
+        limit: match_data[:limit],
+        remaining: 0,
+        retry_after: match_data[:period] - (now % match_data[:period])
+      }
+    }
+  }
+
+  [429, headers, [body.to_json]]
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -43,6 +43,9 @@ Rails.application.routes.draw do
       end
       resources :categories
       resources :tags
+      resource :dashboard, only: [], controller: 'dashboard' do
+        get :stats
+      end
       resources :notes do
         resources :revisions, only: [:index], controller: 'note_revisions' do
           post 'restore', on: :member

--- a/backend/db/migrate/20260218000001_add_full_text_search_to_todos.rb
+++ b/backend/db/migrate/20260218000001_add_full_text_search_to_todos.rb
@@ -1,0 +1,21 @@
+class AddFullTextSearchToTodos < ActiveRecord::Migration[8.0]
+  def up
+    # pg_trgm 拡張を有効化（ILIKE を GIN インデックスで高速化、言語非依存）
+    execute "CREATE EXTENSION IF NOT EXISTS pg_trgm"
+
+    # pg_trgm GIN インデックス（ILIKE の部分一致を高速化）
+    execute <<-SQL.squish
+      CREATE INDEX idx_todos_title_trgm
+      ON todos USING gin(title gin_trgm_ops)
+    SQL
+    execute <<-SQL.squish
+      CREATE INDEX idx_todos_description_trgm
+      ON todos USING gin(description gin_trgm_ops)
+    SQL
+  end
+
+  def down
+    execute "DROP INDEX IF EXISTS idx_todos_title_trgm"
+    execute "DROP INDEX IF EXISTS idx_todos_description_trgm"
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,9 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_01_13_130633) do
+ActiveRecord::Schema[8.0].define(version: 2026_02_18_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
+  enable_extension "pg_trgm"
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -158,13 +159,17 @@ ActiveRecord::Schema[8.0].define(version: 2026_01_13_130633) do
     t.bigint "category_id"
     t.integer "comments_count", default: 0, null: false
     t.integer "todo_histories_count", default: 0, null: false
+    t.tsvector "search_vector"
     t.index ["category_id"], name: "index_todos_on_category_id"
     t.index ["created_at"], name: "index_todos_on_created_at"
+    t.index ["description"], name: "idx_todos_description_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["description"], name: "index_todos_on_description"
     t.index ["due_date"], name: "index_todos_on_due_date"
     t.index ["position"], name: "index_todos_on_position"
     t.index ["priority"], name: "index_todos_on_priority"
+    t.index ["search_vector"], name: "idx_todos_search", using: :gin
     t.index ["status"], name: "index_todos_on_status"
+    t.index ["title"], name: "idx_todos_title_trgm", opclass: :gin_trgm_ops, using: :gin
     t.index ["title"], name: "index_todos_on_title"
     t.index ["updated_at"], name: "index_todos_on_updated_at"
     t.index ["user_id", "category_id"], name: "index_todos_on_user_id_and_category_id"

--- a/backend/spec/jobs/image_variant_job_spec.rb
+++ b/backend/spec/jobs/image_variant_job_spec.rb
@@ -1,0 +1,109 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe ImageVariantJob, type: :job do
+  let(:user) { create(:user) }
+  let(:todo) { create(:todo, user: user) }
+
+  describe '#perform' do
+    context 'with a valid image blob' do
+      let(:blob) do
+        ActiveStorage::Blob.create_and_upload!(
+          io: fixture_file_upload('test_image.png', 'image/png'),
+          filename: 'test_image.png',
+          content_type: 'image/png'
+        )
+      end
+
+      before do
+        todo.files.attach(blob)
+      end
+
+      it 'does not raise an error (gracefully handles missing vips)' do
+        expect { described_class.perform_now(blob.id) }.not_to raise_error
+      end
+    end
+
+    context 'with a non-image blob' do
+      let(:blob) do
+        ActiveStorage::Blob.create_and_upload!(
+          io: StringIO.new('text content'),
+          filename: 'document.txt',
+          content_type: 'text/plain'
+        )
+      end
+
+      before do
+        todo.files.attach(blob)
+      end
+
+      it 'returns early without processing variants' do
+        expect { described_class.perform_now(blob.id) }.not_to raise_error
+        expect(blob.variant_records.count).to eq(0)
+      end
+    end
+
+    context 'with a non-existent blob ID' do
+      it 'returns early without errors' do
+        expect { described_class.perform_now(999_999) }.not_to raise_error
+      end
+    end
+
+    context 'when blob has no files attachment' do
+      let(:blob) do
+        ActiveStorage::Blob.create_and_upload!(
+          io: fixture_file_upload('test_image.png', 'image/png'),
+          filename: 'test_image.png',
+          content_type: 'image/png'
+        )
+      end
+
+      it 'returns early when no files attachment found' do
+        expect { described_class.perform_now(blob.id) }.not_to raise_error
+      end
+    end
+  end
+
+  describe 'job enqueuing from TodoFileService' do
+    let(:image_file) { fixture_file_upload('test_image.png', 'image/png') }
+    let(:text_file) { fixture_file_upload('test_file.txt', 'text/plain') }
+
+    # テスト用にキューアダプタを切り替えてenqueue確認
+    around do |example|
+      original_adapter = ActiveJob::Base.queue_adapter
+      ActiveJob::Base.queue_adapter = :test
+      example.run
+    ensure
+      ActiveJob::Base.queue_adapter = original_adapter
+    end
+
+    context 'when attaching image files' do
+      it 'enqueues ImageVariantJob for images' do
+        service = TodoFileService.new(todo: todo)
+        service.attach([image_file])
+
+        expect(ImageVariantJob).to have_been_enqueued.at_least(:once)
+      end
+    end
+
+    context 'when attaching non-image files' do
+      it 'does not enqueue ImageVariantJob for text files' do
+        service = TodoFileService.new(todo: todo)
+        service.attach([text_file])
+
+        expect(ImageVariantJob).not_to have_been_enqueued
+      end
+    end
+
+    context 'when attaching mixed files' do
+      it 'enqueues ImageVariantJob only for image blobs' do
+        service = TodoFileService.new(todo: todo)
+        service.attach([image_file, text_file])
+
+        # 画像ファイル分だけenqueue される
+        expect(ImageVariantJob).to have_been_enqueued.once
+      end
+    end
+  end
+end

--- a/backend/spec/jobs/image_variant_job_spec.rb
+++ b/backend/spec/jobs/image_variant_job_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe ImageVariantJob, type: :job do
         service = TodoFileService.new(todo: todo)
         service.attach([image_file])
 
-        expect(ImageVariantJob).to have_been_enqueued.at_least(:once)
+        expect(described_class).to have_been_enqueued.at_least(:once)
       end
     end
 
@@ -92,7 +92,7 @@ RSpec.describe ImageVariantJob, type: :job do
         service = TodoFileService.new(todo: todo)
         service.attach([text_file])
 
-        expect(ImageVariantJob).not_to have_been_enqueued
+        expect(described_class).not_to have_been_enqueued
       end
     end
 
@@ -102,7 +102,7 @@ RSpec.describe ImageVariantJob, type: :job do
         service.attach([image_file, text_file])
 
         # 画像ファイル分だけenqueue される
-        expect(ImageVariantJob).to have_been_enqueued.once
+        expect(described_class).to have_been_enqueued.once
       end
     end
   end

--- a/backend/spec/requests/api/v1/dashboard_spec.rb
+++ b/backend/spec/requests/api/v1/dashboard_spec.rb
@@ -1,0 +1,142 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::V1::Dashboard', type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:auth_headers) { auth_headers_for(user) }
+
+  describe 'GET /api/v1/dashboard/stats' do
+    context 'without authentication' do
+      it 'returns 401' do
+        get '/api/v1/dashboard/stats'
+
+        expect(response).to have_http_status(:unauthorized)
+      end
+    end
+
+    context 'with no todos' do
+      it 'returns empty stats' do
+        get '/api/v1/dashboard/stats', headers: auth_headers
+
+        expect(response).to have_http_status(:ok)
+        json = response.parsed_body
+        data = json['data']
+
+        expect(data['completion_stats']['total']).to eq(0)
+        expect(data['completion_stats']['total_completed']).to eq(0)
+        expect(data['priority_breakdown']).to eq(
+          'low' => 0, 'medium' => 0, 'high' => 0
+        )
+        expect(data['status_breakdown']).to eq(
+          'pending' => 0, 'in_progress' => 0, 'completed' => 0
+        )
+        expect(data['category_progress']).to eq([])
+        expect(data['weekly_trend'].length).to eq(7)
+      end
+    end
+
+    context 'with todos' do
+      let!(:category) { create(:category, user: user, name: 'Work', color: '#EF4444') }
+
+      before do
+        create(:todo, user: user, completed: true, status: :completed,
+               priority: :high, category: category,
+               updated_at: Time.current)
+        create(:todo, user: user, completed: true, status: :completed,
+               priority: :medium,
+               updated_at: Time.current)
+        create(:todo, user: user, completed: false, status: :pending,
+               priority: :low, category: category)
+        create(:todo, user: user, completed: false, status: :in_progress,
+               priority: :high)
+      end
+
+      it 'returns completion stats' do
+        get '/api/v1/dashboard/stats', headers: auth_headers
+
+        json = response.parsed_body
+        stats = json['data']['completion_stats']
+
+        expect(stats['total']).to eq(4)
+        expect(stats['total_completed']).to eq(2)
+        expect(stats['today']).to eq(2)
+      end
+
+      it 'returns priority breakdown' do
+        get '/api/v1/dashboard/stats', headers: auth_headers
+
+        json = response.parsed_body
+        breakdown = json['data']['priority_breakdown']
+
+        expect(breakdown['high']).to eq(2)
+        expect(breakdown['medium']).to eq(1)
+        expect(breakdown['low']).to eq(1)
+      end
+
+      it 'returns status breakdown' do
+        get '/api/v1/dashboard/stats', headers: auth_headers
+
+        json = response.parsed_body
+        breakdown = json['data']['status_breakdown']
+
+        expect(breakdown['pending']).to eq(1)
+        expect(breakdown['in_progress']).to eq(1)
+        expect(breakdown['completed']).to eq(2)
+      end
+
+      it 'returns category progress' do
+        get '/api/v1/dashboard/stats', headers: auth_headers
+
+        json = response.parsed_body
+        progress = json['data']['category_progress']
+
+        work_cat = progress.find { |c| c['name'] == 'Work' }
+        expect(work_cat).to be_present
+        expect(work_cat['total']).to eq(2)
+        expect(work_cat['completed']).to eq(1)
+        expect(work_cat['progress']).to eq(50.0)
+      end
+    end
+
+    context 'with weekly trend data' do
+      before do
+        todo = create(:todo, user: user)
+        create(:todo_history, :completed,
+               todo: todo, user: user,
+               created_at: 2.days.ago)
+        create(:todo_history, :completed,
+               todo: todo, user: user,
+               created_at: 1.day.ago)
+        create(:todo_history, :completed,
+               todo: todo, user: user,
+               created_at: Time.current)
+      end
+
+      it 'returns daily completion counts for the past 7 days' do
+        get '/api/v1/dashboard/stats', headers: auth_headers
+
+        json = response.parsed_body
+        trend = json['data']['weekly_trend']
+
+        expect(trend.length).to eq(7)
+        expect(trend.last['date']).to eq(Date.current.iso8601)
+      end
+    end
+
+    context 'data isolation between users' do
+      before do
+        create(:todo, user: user, completed: true, status: :completed)
+        create(:todo, user: other_user, completed: true, status: :completed)
+      end
+
+      it 'only returns data for the current user' do
+        get '/api/v1/dashboard/stats', headers: auth_headers
+
+        json = response.parsed_body
+        expect(json['data']['completion_stats']['total']).to eq(1)
+      end
+    end
+  end
+end

--- a/backend/spec/requests/api/v1/dashboard_spec.rb
+++ b/backend/spec/requests/api/v1/dashboard_spec.rb
@@ -42,15 +42,15 @@ RSpec.describe 'Api::V1::Dashboard', type: :request do
 
       before do
         create(:todo, user: user, completed: true, status: :completed,
-               priority: :high, category: category,
-               updated_at: Time.current)
+                      priority: :high, category: category,
+                      updated_at: Time.current)
         create(:todo, user: user, completed: true, status: :completed,
-               priority: :medium,
-               updated_at: Time.current)
+                      priority: :medium,
+                      updated_at: Time.current)
         create(:todo, user: user, completed: false, status: :pending,
-               priority: :low, category: category)
+                      priority: :low, category: category)
         create(:todo, user: user, completed: false, status: :in_progress,
-               priority: :high)
+                      priority: :high)
       end
 
       it 'returns completion stats' do

--- a/backend/spec/requests/rack_attack_spec.rb
+++ b/backend/spec/requests/rack_attack_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Rack::Attack Rate Limiting', type: :request do
+  include AuthenticationHelpers
+
+  before do
+    # テスト用にRack::Attackを有効化してリセット
+    Rack::Attack.enabled = true
+    Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+    Rack::Attack.reset!
+  end
+
+  after do
+    Rack::Attack.reset!
+    Rack::Attack.enabled = false
+  end
+
+  describe 'authenticated user rate limiting (100 req/min per user)' do
+    let(:user) { create(:user) }
+
+    it 'allows requests within the limit' do
+      headers = auth_headers_for(user)
+      Rack::Attack.reset!
+
+      get '/api/v1/categories', headers: headers
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'throttles by user ID extracted from JWT, not by IP' do
+      headers = auth_headers_for(user)
+      Rack::Attack.reset!
+
+      # ユーザーIDベースのスロットリングなのでBFFパターンでも正しく動作
+      100.times do
+        get '/api/v1/categories', headers: headers
+      end
+
+      # 101回目は429
+      get '/api/v1/categories', headers: headers
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it 'returns proper rate limit headers when throttled' do
+      headers = auth_headers_for(user)
+      Rack::Attack.reset!
+
+      101.times do
+        get '/api/v1/categories', headers: headers
+      end
+
+      expect(response.headers['X-RateLimit-Limit']).to eq('100')
+      expect(response.headers['X-RateLimit-Remaining']).to eq('0')
+      expect(response.headers['Retry-After']).to be_present
+    end
+
+    it 'returns JSON error body when throttled' do
+      headers = auth_headers_for(user)
+      Rack::Attack.reset!
+
+      101.times do
+        get '/api/v1/categories', headers: headers
+      end
+
+      body = response.parsed_body
+      expect(body['error']['code']).to eq('RATE_LIMIT_EXCEEDED')
+      expect(body['error']['message']).to eq('Rate limit exceeded. Please try again later.')
+      expect(body['error']['details']['limit']).to eq(100)
+      expect(body['error']['details']['remaining']).to eq(0)
+    end
+
+    it 'tracks different users independently' do
+      other_user = create(:user)
+      headers = auth_headers_for(user)
+      other_headers = auth_headers_for(other_user)
+      Rack::Attack.reset!
+
+      # ユーザー1が99回リクエスト
+      99.times do
+        get '/api/v1/categories', headers: headers
+      end
+
+      # ユーザー2はまだ制限に達していない
+      get '/api/v1/categories', headers: other_headers
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe 'unauthenticated user rate limiting (20 req/min per IP)' do
+    it 'allows requests within the limit' do
+      get '/api/v1/categories'
+      expect(response.status).not_to eq(429)
+    end
+
+    it 'returns 429 when unauthenticated rate limit is exceeded' do
+      20.times do
+        get '/api/v1/categories'
+      end
+
+      get '/api/v1/categories'
+      expect(response).to have_http_status(:too_many_requests)
+    end
+
+    it 'returns proper JSON error for unauthenticated throttling' do
+      21.times do
+        get '/api/v1/categories'
+      end
+
+      body = response.parsed_body
+      expect(body['error']['code']).to eq('RATE_LIMIT_EXCEEDED')
+      expect(body['error']['details']['limit']).to eq(20)
+    end
+  end
+end

--- a/backend/spec/services/dashboard_stats_service_spec.rb
+++ b/backend/spec/services/dashboard_stats_service_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe DashboardStatsService do
+  let(:user) { create(:user) }
+
+  subject(:service) { described_class.new(user: user) }
+
+  describe '#call' do
+    it 'returns all expected keys' do
+      result = service.call
+
+      expect(result).to have_key(:completion_stats)
+      expect(result).to have_key(:priority_breakdown)
+      expect(result).to have_key(:status_breakdown)
+      expect(result).to have_key(:category_progress)
+      expect(result).to have_key(:weekly_trend)
+    end
+  end
+
+  describe 'completion_stats' do
+    context 'with completed todos at different times' do
+      before do
+        create(:todo, user: user, completed: true, status: :completed,
+               updated_at: Time.current)
+        create(:todo, user: user, completed: true, status: :completed,
+               updated_at: 3.days.ago)
+        create(:todo, user: user, completed: false, status: :pending)
+      end
+
+      it 'counts today completions' do
+        stats = service.call[:completion_stats]
+        expect(stats[:today]).to eq(1)
+      end
+
+      it 'counts week completions' do
+        stats = service.call[:completion_stats]
+        expect(stats[:this_week]).to be >= 1
+      end
+
+      it 'counts month completions' do
+        stats = service.call[:completion_stats]
+        expect(stats[:this_month]).to be >= 1
+      end
+
+      it 'counts total and total_completed' do
+        stats = service.call[:completion_stats]
+        expect(stats[:total]).to eq(3)
+        expect(stats[:total_completed]).to eq(2)
+      end
+    end
+  end
+
+  describe 'priority_breakdown' do
+    before do
+      create(:todo, user: user, priority: :low)
+      create(:todo, user: user, priority: :low)
+      create(:todo, user: user, priority: :high)
+    end
+
+    it 'groups todos by priority' do
+      breakdown = service.call[:priority_breakdown]
+      expect(breakdown[:low]).to eq(2)
+      expect(breakdown[:medium]).to eq(0)
+      expect(breakdown[:high]).to eq(1)
+    end
+  end
+
+  describe 'status_breakdown' do
+    before do
+      create(:todo, user: user, status: :pending)
+      create(:todo, user: user, status: :in_progress)
+      create(:todo, user: user, status: :in_progress)
+      create(:todo, user: user, status: :completed, completed: true)
+    end
+
+    it 'groups todos by status' do
+      breakdown = service.call[:status_breakdown]
+      expect(breakdown[:pending]).to eq(1)
+      expect(breakdown[:in_progress]).to eq(2)
+      expect(breakdown[:completed]).to eq(1)
+    end
+  end
+
+  describe 'category_progress' do
+    let!(:category) { create(:category, user: user, name: 'Dev') }
+
+    before do
+      create(:todo, user: user, category: category, completed: true)
+      create(:todo, user: user, category: category, completed: false)
+    end
+
+    it 'returns progress per category' do
+      progress = service.call[:category_progress]
+      dev = progress.find { |c| c[:name] == 'Dev' }
+
+      expect(dev[:total]).to eq(2)
+      expect(dev[:completed]).to eq(1)
+      expect(dev[:progress]).to eq(50.0)
+    end
+
+    it 'returns 0 progress for empty category' do
+      empty_cat = create(:category, user: user, name: 'Empty')
+
+      progress = service.call[:category_progress]
+      empty = progress.find { |c| c[:name] == empty_cat.name }
+
+      expect(empty[:total]).to eq(0)
+      expect(empty[:progress]).to eq(0.0)
+    end
+  end
+
+  describe 'weekly_trend' do
+    before do
+      todo = create(:todo, user: user)
+      create(:todo_history, :completed,
+             todo: todo, user: user,
+             created_at: Date.current.beginning_of_day + 10.hours)
+      create(:todo_history, :completed,
+             todo: todo, user: user,
+             created_at: 1.day.ago.beginning_of_day + 10.hours)
+    end
+
+    it 'returns 7 days of data' do
+      trend = service.call[:weekly_trend]
+      expect(trend.length).to eq(7)
+    end
+
+    it 'includes correct dates' do
+      trend = service.call[:weekly_trend]
+      dates = trend.map { |d| d[:date] }
+
+      expect(dates.first).to eq((Date.current - 6.days).iso8601)
+      expect(dates.last).to eq(Date.current.iso8601)
+    end
+
+    it 'counts completions per day' do
+      trend = service.call[:weekly_trend]
+      today_data = trend.find { |d| d[:date] == Date.current.iso8601 }
+      yesterday_data = trend.find { |d| d[:date] == 1.day.ago.to_date.iso8601 }
+
+      expect(today_data[:count]).to eq(1)
+      expect(yesterday_data[:count]).to eq(1)
+    end
+
+    it 'filters by todo owner, not history author' do
+      other_user = create(:user)
+      other_todo = create(:todo, user: other_user)
+      # History authored by our user but on another user's todo
+      create(:todo_history, :completed,
+             todo: other_todo, user: user,
+             created_at: Date.current.beginning_of_day + 10.hours)
+
+      trend = service.call[:weekly_trend]
+      today_data = trend.find { |d| d[:date] == Date.current.iso8601 }
+
+      # Should only count the history on user's own todo
+      expect(today_data[:count]).to eq(1)
+    end
+  end
+end

--- a/backend/spec/services/dashboard_stats_service_spec.rb
+++ b/backend/spec/services/dashboard_stats_service_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe DashboardStatsService do
-  let(:user) { create(:user) }
-
   subject(:service) { described_class.new(user: user) }
+
+  let(:user) { create(:user) }
 
   describe '#call' do
     it 'returns all expected keys' do
@@ -23,9 +23,9 @@ RSpec.describe DashboardStatsService do
     context 'with completed todos at different times' do
       before do
         create(:todo, user: user, completed: true, status: :completed,
-               updated_at: Time.current)
+                      updated_at: Time.current)
         create(:todo, user: user, completed: true, status: :completed,
-               updated_at: 3.days.ago)
+                      updated_at: 3.days.ago)
         create(:todo, user: user, completed: false, status: :pending)
       end
 
@@ -129,7 +129,7 @@ RSpec.describe DashboardStatsService do
 
     it 'includes correct dates' do
       trend = service.call[:weekly_trend]
-      dates = trend.map { |d| d[:date] }
+      dates = trend.pluck(:date)
 
       expect(dates.first).to eq((Date.current - 6.days).iso8601)
       expect(dates.last).to eq(Date.current.iso8601)

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -2,7 +2,18 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   experimental: {
-    optimizePackageImports: ["lucide-react", "date-fns", "@radix-ui/react-icons"],
+    optimizePackageImports: [
+      "lucide-react",
+      "date-fns",
+      "@radix-ui/react-icons",
+      "@radix-ui/react-dialog",
+      "@radix-ui/react-select",
+      "@radix-ui/react-checkbox",
+      "@radix-ui/react-collapsible",
+      "@radix-ui/react-radio-group",
+      "@radix-ui/react-popover",
+      "sonner",
+    ],
   },
 };
 

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,0 +1,25 @@
+import { Navigation } from "@/components/navigation";
+import { DashboardPage } from
+  "@/features/dashboard/components/DashboardPage";
+import { fetchDashboardData } from
+  "@/features/dashboard/lib/server-fetcher";
+
+/**
+ * Dashboard page - async Server Component
+ *
+ * Fetches initial dashboard stats on the server for SSR,
+ * then hands off to the client component for SWR revalidation.
+ * Authentication is handled by middleware.
+ */
+export default async function Dashboard() {
+  const initialStats = await fetchDashboardData();
+
+  return (
+    <div className="min-h-screen bg-background">
+      <Navigation />
+      <div className="container mx-auto px-4 py-8 max-w-5xl">
+        <DashboardPage initialStats={initialStats} />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import { Toaster } from "@/components/ui/sonner";
 import { AuthProvider } from "@/contexts/auth-context";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { KeyboardShortcutProvider } from "@/components/KeyboardShortcutProvider";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -29,10 +31,14 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <AuthProvider>
-          {children}
-          <Toaster />
-        </AuthProvider>
+        <ErrorBoundary>
+          <AuthProvider>
+            <KeyboardShortcutProvider>
+              {children}
+            </KeyboardShortcutProvider>
+            <Toaster />
+          </AuthProvider>
+        </ErrorBoundary>
       </body>
     </html>
   );

--- a/frontend/src/app/notes/page.tsx
+++ b/frontend/src/app/notes/page.tsx
@@ -1,4 +1,5 @@
 import { Navigation } from "@/components/navigation";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { NotesWorkspace } from "@/features/notes/components/NotesWorkspace";
 
 /**
@@ -11,7 +12,9 @@ export default function NotesPage() {
     <div className="min-h-screen bg-background">
       <Navigation />
       <div className="container mx-auto px-4 py-8 max-w-6xl">
-        <NotesWorkspace />
+        <ErrorBoundary>
+          <NotesWorkspace />
+        </ErrorBoundary>
       </div>
     </div>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { TodoListWithSearch } from "@/features/todo/components/TodoListWithSearch";
 import { Navigation } from "@/components/navigation";
+import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { fetchInitialTodoData } from "@/features/todo/lib/server-fetcher";
 
 /**
@@ -16,12 +17,14 @@ export default async function Home() {
     <div className="min-h-screen bg-background">
       <Navigation />
       <div className="container mx-auto px-4 py-8 max-w-4xl">
-        <TodoListWithSearch
-          initialTodos={initialData.todos}
-          initialCategories={initialData.categories}
-          initialTags={initialData.tags}
-          initialSearchResponse={initialData.searchResponse}
-        />
+        <ErrorBoundary>
+          <TodoListWithSearch
+            initialTodos={initialData.todos}
+            initialCategories={initialData.categories}
+            initialTags={initialData.tags}
+            initialSearchResponse={initialData.searchResponse}
+          />
+        </ErrorBoundary>
       </div>
     </div>
   );

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import {
+  useState,
+  useMemo,
+  useCallback,
+  useEffect,
+  useRef,
+} from "react";
+import { Search, Plus, Keyboard } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { cn, getModKeyLabel } from "@/lib/utils";
+
+/** コマンドパレットのアクション定義 */
+interface CommandAction {
+  id: string;
+  label: string;
+  icon: React.ReactNode;
+  shortcut?: string;
+  onSelect: () => void;
+}
+
+interface CommandPaletteProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreateTodo: () => void;
+  onShowShortcuts: () => void;
+}
+
+/**
+ * Cmd+K で起動するコマンドパレットコンポーネント
+ *
+ * テキスト入力でアクションをフィルタリングし、
+ * キーボード操作（上下矢印、Enter）で選択・実行できる。
+ */
+export function CommandPalette({
+  open,
+  onOpenChange,
+  onCreateTodo,
+  onShowShortcuts,
+}: CommandPaletteProps) {
+  const [query, setQuery] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const modKey = getModKeyLabel();
+
+  const actions: CommandAction[] = useMemo(() => [
+    {
+      id: "create-todo",
+      label: "新規タスクを作成",
+      icon: <Plus className="h-4 w-4" />,
+      shortcut: `${modKey}+N`,
+      onSelect: () => {
+        onOpenChange(false);
+        onCreateTodo();
+      },
+    },
+    {
+      id: "shortcuts",
+      label: "キーボードショートカットを表示",
+      icon: <Keyboard className="h-4 w-4" />,
+      shortcut: "?",
+      onSelect: () => {
+        onOpenChange(false);
+        onShowShortcuts();
+      },
+    },
+  ], [modKey, onOpenChange, onCreateTodo, onShowShortcuts]);
+
+  const filteredActions = useMemo(() => {
+    if (!query) return actions;
+    const lower = query.toLowerCase();
+    return actions.filter((action) =>
+      action.label.toLowerCase().includes(lower),
+    );
+  }, [query, actions]);
+
+  const handleQueryChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setQuery(e.target.value);
+      setSelectedIndex(0);
+    },
+    [],
+  );
+
+  const handleOpenChange = useCallback(
+    (nextOpen: boolean) => {
+      if (nextOpen) {
+        setQuery("");
+        setSelectedIndex(0);
+      }
+      onOpenChange(nextOpen);
+    },
+    [onOpenChange],
+  );
+
+  // ダイアログが開いたらinputにフォーカス
+  useEffect(() => {
+    if (open) {
+      requestAnimationFrame(() => {
+        inputRef.current?.focus();
+      });
+    }
+  }, [open]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case "ArrowDown": {
+          e.preventDefault();
+          setSelectedIndex((prev) =>
+            Math.min(prev + 1, filteredActions.length - 1),
+          );
+          break;
+        }
+        case "ArrowUp": {
+          e.preventDefault();
+          setSelectedIndex((prev) => Math.max(prev - 1, 0));
+          break;
+        }
+        case "Enter": {
+          e.preventDefault();
+          if (filteredActions[selectedIndex]) {
+            filteredActions[selectedIndex].onSelect();
+          }
+          break;
+        }
+      }
+    },
+    [filteredActions, selectedIndex],
+  );
+
+  // 選択項目が変わったらスクロール
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const selected = list.children[selectedIndex] as
+      | HTMLElement
+      | undefined;
+    selected?.scrollIntoView({ block: "nearest" });
+  }, [selectedIndex]);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="sm:max-w-md p-0 gap-0 overflow-hidden"
+        aria-label="コマンドパレット"
+      >
+        <div className="flex items-center border-b px-3">
+          <Search className="h-4 w-4 shrink-0 text-muted-foreground" />
+          <Input
+            ref={inputRef}
+            value={query}
+            onChange={handleQueryChange}
+            onKeyDown={handleKeyDown}
+            placeholder="コマンドを入力..."
+            className="border-0 focus-visible:ring-0 focus-visible:ring-offset-0 h-11"
+          />
+        </div>
+
+        <div
+          ref={listRef}
+          className="max-h-[300px] overflow-y-auto p-2"
+          role="listbox"
+          aria-label="コマンド一覧"
+        >
+          {filteredActions.length === 0
+            ? (
+                <div className="py-6 text-center text-sm text-muted-foreground">
+                  一致するコマンドがありません
+                </div>
+              )
+            : (
+                filteredActions.map((action, index) => (
+                  <button
+                    key={action.id}
+                    type="button"
+                    role="option"
+                    aria-selected={index === selectedIndex}
+                    className={cn(
+                      "flex w-full items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors",
+                      index === selectedIndex
+                        ? "bg-accent text-accent-foreground"
+                        : "hover:bg-accent/50",
+                    )}
+                    onClick={() => action.onSelect()}
+                    onMouseEnter={() => setSelectedIndex(index)}
+                  >
+                    <span className="shrink-0 text-muted-foreground">
+                      {action.icon}
+                    </span>
+                    <span className="flex-1 text-left">
+                      {action.label}
+                    </span>
+                    {action.shortcut && (
+                      <kbd className="ml-auto inline-flex h-5 items-center rounded border bg-muted px-1.5 font-mono text-[10px] text-muted-foreground">
+                        {action.shortcut}
+                      </kbd>
+                    )}
+                  </button>
+                ))
+              )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/ErrorBoundary.tsx
+++ b/frontend/src/components/ErrorBoundary.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { Component } from "react";
+import type { ErrorInfo, ReactNode } from "react";
+import { Button } from "@/components/ui/button";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** エラー時に表示するカスタムフォールバックUI */
+  fallback?: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: Error | null;
+}
+
+/**
+ * Reactエラーバウンダリコンポーネント
+ *
+ * 子コンポーネントツリー内で発生したJavaScriptエラーを
+ * キャッチし、アプリ全体のクラッシュを防止する。
+ * エラー発生時はフォールバックUIを表示し、
+ * ユーザーにリカバリー手段を提供する。
+ */
+export class ErrorBoundary extends Component<
+  ErrorBoundaryProps,
+  ErrorBoundaryState
+> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error(
+      "[ErrorBoundary] Uncaught error:",
+      error,
+      errorInfo,
+    );
+  }
+
+  private handleReset = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return (
+        <div className="flex flex-col items-center justify-center min-h-[200px] p-8 text-center">
+          <h2 className="text-lg font-semibold mb-2">
+            予期しないエラーが発生しました
+          </h2>
+          <p className="text-sm text-muted-foreground mb-4">
+            {this.state.error?.message
+              || "アプリケーションでエラーが発生しました。"}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              onClick={this.handleReset}
+            >
+              再試行
+            </Button>
+            <Button
+              variant="default"
+              onClick={() => window.location.reload()}
+            >
+              ページを再読み込み
+            </Button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/KeyboardShortcutProvider.tsx
+++ b/frontend/src/components/KeyboardShortcutProvider.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useMemo,
+} from "react";
+import type { ReactNode } from "react";
+import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { CommandPalette } from "@/components/CommandPalette";
+import { ShortcutHelp } from "@/components/ShortcutHelp";
+
+interface KeyboardShortcutContextValue {
+  /** コマンドパレットを開く */
+  openCommandPalette: () => void;
+  /** ショートカットヘルプを開く */
+  openShortcutHelp: () => void;
+  /** 新規タスク作成ハンドラーを登録 */
+  registerCreateTodo: (handler: () => void) => void;
+}
+
+const KeyboardShortcutContext
+  = createContext<KeyboardShortcutContextValue | null>(null);
+
+/**
+ * キーボードショートカットコンテキストを取得するhook
+ */
+export function useKeyboardShortcutContext(): KeyboardShortcutContextValue {
+  const ctx = useContext(KeyboardShortcutContext);
+  if (!ctx) {
+    throw new Error(
+      "useKeyboardShortcutContext must be used within "
+      + "KeyboardShortcutProvider",
+    );
+  }
+  return ctx;
+}
+
+interface KeyboardShortcutProviderProps {
+  children: ReactNode;
+}
+
+/**
+ * グローバルキーボードショートカットを管理するプロバイダー
+ *
+ * Cmd/Ctrl+K でコマンドパレット、? でヘルプ表示、
+ * Cmd/Ctrl+N で新規タスク作成をトリガーする。
+ */
+export function KeyboardShortcutProvider({
+  children,
+}: KeyboardShortcutProviderProps) {
+  const [commandPaletteOpen, setCommandPaletteOpen]
+    = useState(false);
+  const [shortcutHelpOpen, setShortcutHelpOpen]
+    = useState(false);
+
+  // 外部から登録される新規タスク作成ハンドラー
+  const [createTodoHandler, setCreateTodoHandler]
+    = useState<(() => void) | null>(null);
+
+  const openCommandPalette = useCallback(() => {
+    setCommandPaletteOpen(true);
+  }, []);
+
+  const openShortcutHelp = useCallback(() => {
+    setShortcutHelpOpen(true);
+  }, []);
+
+  const registerCreateTodo = useCallback(
+    (handler: () => void) => {
+      setCreateTodoHandler(() => handler);
+    },
+    [],
+  );
+
+  const handleCreateTodo = useCallback(() => {
+    if (createTodoHandler) {
+      createTodoHandler();
+    }
+  }, [createTodoHandler]);
+
+  // グローバルショートカット登録
+  useKeyboardShortcuts(
+    useMemo(
+      () => [
+        {
+          key: "k",
+          meta: true,
+          handler: openCommandPalette,
+        },
+        {
+          key: "n",
+          meta: true,
+          handler: handleCreateTodo,
+        },
+        {
+          key: "?",
+          handler: openShortcutHelp,
+        },
+      ],
+      [openCommandPalette, handleCreateTodo, openShortcutHelp],
+    ),
+    !commandPaletteOpen && !shortcutHelpOpen,
+  );
+
+  const contextValue = useMemo(
+    () => ({
+      openCommandPalette,
+      openShortcutHelp,
+      registerCreateTodo,
+    }),
+    [openCommandPalette, openShortcutHelp, registerCreateTodo],
+  );
+
+  return (
+    <KeyboardShortcutContext.Provider value={contextValue}>
+      {children}
+      <CommandPalette
+        open={commandPaletteOpen}
+        onOpenChange={setCommandPaletteOpen}
+        onCreateTodo={handleCreateTodo}
+        onShowShortcuts={() => {
+          setCommandPaletteOpen(false);
+          setShortcutHelpOpen(true);
+        }}
+      />
+      <ShortcutHelp
+        open={shortcutHelpOpen}
+        onOpenChange={setShortcutHelpOpen}
+      />
+    </KeyboardShortcutContext.Provider>
+  );
+}

--- a/frontend/src/components/ShortcutHelp.tsx
+++ b/frontend/src/components/ShortcutHelp.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { getModKeyLabel } from "@/lib/utils";
+
+interface ShortcutHelpProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface ShortcutEntry {
+  keys: string[];
+  description: string;
+}
+
+interface ShortcutGroup {
+  title: string;
+  shortcuts: ShortcutEntry[];
+}
+
+const modKey = getModKeyLabel();
+
+const shortcutGroups: ShortcutGroup[] = [
+  {
+    title: "グローバル",
+    shortcuts: [
+      {
+        keys: [`${modKey}+K`],
+        description: "コマンドパレットを開く",
+      },
+      { keys: [`${modKey}+N`], description: "新規タスクを作成" },
+      { keys: ["?"], description: "ショートカット一覧を表示" },
+      { keys: ["Escape"], description: "ダイアログを閉じる" },
+    ],
+  },
+];
+
+/**
+ * キーボードショートカット一覧を表示するヘルプダイアログ
+ */
+export function ShortcutHelp({
+  open,
+  onOpenChange,
+}: ShortcutHelpProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>キーボードショートカット</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-6 py-4">
+          {shortcutGroups.map((group) => (
+            <div key={group.title} className="space-y-3">
+              <h3 className="text-sm font-semibold text-muted-foreground">
+                {group.title}
+              </h3>
+              <div className="space-y-2">
+                {group.shortcuts.map((shortcut) => (
+                  <div
+                    key={shortcut.description}
+                    className="flex items-center justify-between"
+                  >
+                    <span className="text-sm">
+                      {shortcut.description}
+                    </span>
+                    <div className="flex items-center gap-1">
+                      {shortcut.keys.map((key) => (
+                        <kbd
+                          key={key}
+                          className="inline-flex h-6 items-center rounded border bg-muted px-1.5 font-mono text-xs text-muted-foreground"
+                        >
+                          {key}
+                        </kbd>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/navigation.tsx
+++ b/frontend/src/components/navigation.tsx
@@ -37,6 +37,9 @@ export function Navigation() {
               <Link href="/notes" className="text-sm text-gray-600 hover:text-gray-900">
                 ノート
               </Link>
+              <Link href="/dashboard" className="text-sm text-gray-600 hover:text-gray-900">
+                ダッシュボード
+              </Link>
             </>
           )}
         </div>

--- a/frontend/src/features/dashboard/components/CategoryProgress.tsx
+++ b/frontend/src/features/dashboard/components/CategoryProgress.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import type {
+  CategoryProgress as CategoryProgressData,
+} from "../types/dashboard";
+
+/** Props for CategoryProgress component */
+interface CategoryProgressProps {
+  categories: CategoryProgressData[];
+}
+
+/**
+ * Displays progress bars for each category
+ * showing completion rate with color coding
+ */
+export function CategoryProgress({
+  categories,
+}: CategoryProgressProps) {
+  if (categories.length === 0) {
+    return (
+      <div className="bg-white rounded-lg border border-gray-200 p-5">
+        <h3 className="text-sm font-medium text-gray-500 mb-4">
+          カテゴリ別進捗
+        </h3>
+        <p className="text-sm text-gray-400">
+          カテゴリがありません
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-5">
+      <h3 className="text-sm font-medium text-gray-500 mb-4">
+        カテゴリ別進捗
+      </h3>
+      <div className="space-y-4">
+        {categories.map((cat) => (
+          <div key={cat.id}>
+            <div className="flex items-center justify-between mb-1">
+              <div className="flex items-center gap-2">
+                <span
+                  className="inline-block h-3 w-3 rounded-full"
+                  style={{ backgroundColor: cat.color }}
+                  aria-hidden="true"
+                />
+                <span className="text-sm font-medium text-gray-700">
+                  {cat.name}
+                </span>
+              </div>
+              <span className="text-xs text-gray-500">
+                {cat.completed}
+                /
+                {cat.total}
+                (
+                {cat.progress}
+                %)
+              </span>
+            </div>
+            <div
+              className="h-2 w-full rounded-full bg-gray-100"
+              role="progressbar"
+              aria-valuenow={cat.progress}
+              aria-valuemin={0}
+              aria-valuemax={100}
+              aria-label={
+                `${cat.name}: ${cat.progress}% 完了`
+              }
+            >
+              <div
+                className="h-2 rounded-full transition-all duration-300"
+                style={{
+                  width: `${cat.progress}%`,
+                  backgroundColor: cat.color,
+                }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/components/DashboardPage.tsx
+++ b/frontend/src/features/dashboard/components/DashboardPage.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { memo } from "react";
+import { useDashboardStats } from "../hooks/useDashboardStats";
+import { StatCard } from "./StatCard";
+import { WeeklyChart } from "./WeeklyChart";
+import { CategoryProgress } from "./CategoryProgress";
+import type { DashboardStats } from "../types/dashboard";
+
+/** Props for DashboardPage component */
+interface DashboardPageProps {
+  initialStats: DashboardStats | null;
+}
+
+/**
+ * Main dashboard client component
+ *
+ * Receives SSR data as initialStats and uses SWR
+ * for client-side revalidation via fallbackData pattern.
+ */
+export function DashboardPage({
+  initialStats,
+}: DashboardPageProps) {
+  const { stats, isLoading, error } = useDashboardStats({
+    fallbackData: initialStats ?? undefined,
+  });
+
+  if (error) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-destructive">
+          データの取得に失敗しました
+        </p>
+      </div>
+    );
+  }
+
+  if (isLoading && !stats) {
+    return (
+      <div className="space-y-6 animate-pulse">
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {[...Array(4)].map((_, i) => (
+            <div
+              key={i}
+              className="h-24 bg-gray-200 rounded-lg"
+            />
+          ))}
+        </div>
+        <div className="h-64 bg-gray-200 rounded-lg" />
+      </div>
+    );
+  }
+
+  if (!stats) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-gray-500">データがありません</p>
+      </div>
+    );
+  }
+
+  const { completion_stats, status_breakdown } = stats;
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold text-gray-900">
+        ダッシュボード
+      </h1>
+
+      {/* Completion stats */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <StatCard
+          label="今日の完了"
+          value={completion_stats.today}
+          accentColor="bg-green-500"
+        />
+        <StatCard
+          label="今週の完了"
+          value={completion_stats.this_week}
+          accentColor="bg-blue-500"
+        />
+        <StatCard
+          label="今月の完了"
+          value={completion_stats.this_month}
+          accentColor="bg-purple-500"
+        />
+        <StatCard
+          label="全体の完了率"
+          value={
+            completion_stats.total > 0
+              ? Math.round(
+                  completion_stats.total_completed
+                  / completion_stats.total * 100,
+                )
+              : 0
+          }
+          subtitle={
+            `${completion_stats.total_completed}`
+            + `/${completion_stats.total} 完了`
+          }
+          accentColor="bg-amber-500"
+        />
+      </div>
+
+      {/* Status and Priority breakdown */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <div
+          className="bg-white rounded-lg border border-gray-200 p-5"
+        >
+          <h3
+            className="text-sm font-medium text-gray-500 mb-3"
+          >
+            ステータス別
+          </h3>
+          <div className="space-y-2">
+            <StatusRow
+              label="未着手"
+              count={status_breakdown.pending}
+              color="bg-gray-400"
+              total={completion_stats.total}
+            />
+            <StatusRow
+              label="進行中"
+              count={status_breakdown.in_progress}
+              color="bg-blue-500"
+              total={completion_stats.total}
+            />
+            <StatusRow
+              label="完了"
+              count={status_breakdown.completed}
+              color="bg-green-500"
+              total={completion_stats.total}
+            />
+          </div>
+        </div>
+        <div
+          className="bg-white rounded-lg border border-gray-200 p-5"
+        >
+          <h3
+            className="text-sm font-medium text-gray-500 mb-3"
+          >
+            優先度別
+          </h3>
+          <div className="space-y-2">
+            <StatusRow
+              label="高"
+              count={stats.priority_breakdown.high}
+              color="bg-red-500"
+              total={completion_stats.total}
+            />
+            <StatusRow
+              label="中"
+              count={stats.priority_breakdown.medium}
+              color="bg-amber-500"
+              total={completion_stats.total}
+            />
+            <StatusRow
+              label="低"
+              count={stats.priority_breakdown.low}
+              color="bg-gray-400"
+              total={completion_stats.total}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Weekly trend chart */}
+      <WeeklyChart data={stats.weekly_trend} />
+
+      {/* Category progress */}
+      <CategoryProgress
+        categories={stats.category_progress}
+      />
+    </div>
+  );
+}
+
+/** Internal memoized component for status/priority rows */
+const StatusRow = memo(function StatusRow({
+  label,
+  count,
+  color,
+  total,
+}: {
+  label: string;
+  count: number;
+  color: string;
+  total: number;
+}) {
+  const pct = total > 0
+    ? Math.round((count / total) * 100)
+    : 0;
+
+  return (
+    <div className="flex items-center gap-3">
+      <span
+        className={`h-2.5 w-2.5 rounded-full ${color}`}
+        aria-hidden="true"
+      />
+      <span className="text-sm text-gray-700 w-16">
+        {label}
+      </span>
+      <div className="flex-1 h-2 bg-gray-100 rounded-full">
+        <div
+          className={`h-2 rounded-full ${color}`}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+      <span className="text-sm text-gray-500 w-16 text-right">
+        {count}
+        {" "}
+        (
+        {pct}
+        %)
+      </span>
+    </div>
+  );
+});

--- a/frontend/src/features/dashboard/components/StatCard.tsx
+++ b/frontend/src/features/dashboard/components/StatCard.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+/** Props for StatCard component */
+interface StatCardProps {
+  label: string;
+  value: number;
+  subtitle?: string;
+  accentColor?: string;
+}
+
+/**
+ * A card displaying a single statistic with label and value
+ */
+export function StatCard({
+  label,
+  value,
+  subtitle,
+  accentColor = "bg-blue-500",
+}: StatCardProps) {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-5">
+      <div className="flex items-start justify-between">
+        <div>
+          <p className="text-sm font-medium text-gray-500">
+            {label}
+          </p>
+          <p className="mt-1 text-3xl font-bold text-gray-900">
+            {value}
+          </p>
+          {subtitle && (
+            <p className="mt-1 text-xs text-gray-400">
+              {subtitle}
+            </p>
+          )}
+        </div>
+        <div
+          className={`h-3 w-3 rounded-full ${accentColor}`}
+          aria-hidden="true"
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/components/WeeklyChart.tsx
+++ b/frontend/src/features/dashboard/components/WeeklyChart.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { parseISO, format } from "date-fns";
+import { ja } from "date-fns/locale";
+import type { DailyCompletion } from "../types/dashboard";
+
+/** Props for WeeklyChart component */
+interface WeeklyChartProps {
+  data: DailyCompletion[];
+}
+
+/**
+ * Simple SVG bar chart showing daily completions
+ * for the past 7 days. No external chart library required.
+ */
+export function WeeklyChart({ data }: WeeklyChartProps) {
+  const maxCount = Math.max(...data.map((d) => d.count), 1);
+  const chartHeight = 160;
+  const barWidth = 36;
+  const gap = 12;
+  const chartWidth = data.length * (barWidth + gap) - gap;
+
+  const formatDay = (dateStr: string) => {
+    return format(parseISO(dateStr), "E", { locale: ja });
+  };
+
+  const formatDate = (dateStr: string) => {
+    return format(parseISO(dateStr), "M/d");
+  };
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-5">
+      <h3 className="text-sm font-medium text-gray-500 mb-4">
+        週間完了トレンド
+      </h3>
+      <div className="overflow-x-auto">
+        <svg
+          width={chartWidth + 20}
+          height={chartHeight + 50}
+          viewBox={
+            `0 0 ${chartWidth + 20} ${chartHeight + 50}`
+          }
+          className="mx-auto"
+          role="img"
+          aria-label="週間完了トレンドのバーチャート"
+        >
+          {data.map((item, i) => {
+            const barHeight = maxCount > 0
+              ? (item.count / maxCount) * chartHeight
+              : 0;
+            const x = 10 + i * (barWidth + gap);
+            const y = chartHeight - barHeight;
+
+            return (
+              <g key={item.date}>
+                {/* Bar background */}
+                <rect
+                  x={x}
+                  y={0}
+                  width={barWidth}
+                  height={chartHeight}
+                  rx={4}
+                  fill="#F3F4F6"
+                />
+                {/* Bar value */}
+                <rect
+                  x={x}
+                  y={y}
+                  width={barWidth}
+                  height={barHeight}
+                  rx={4}
+                  fill="#3B82F6"
+                  className="transition-all duration-300"
+                />
+                {/* Count label */}
+                {item.count > 0 && (
+                  <text
+                    x={x + barWidth / 2}
+                    y={y - 6}
+                    textAnchor="middle"
+                    className="fill-gray-700 text-xs font-medium"
+                    fontSize="12"
+                  >
+                    {item.count}
+                  </text>
+                )}
+                {/* Day label */}
+                <text
+                  x={x + barWidth / 2}
+                  y={chartHeight + 16}
+                  textAnchor="middle"
+                  className="fill-gray-500"
+                  fontSize="11"
+                >
+                  {formatDay(item.date)}
+                </text>
+                {/* Date label */}
+                <text
+                  x={x + barWidth / 2}
+                  y={chartHeight + 32}
+                  textAnchor="middle"
+                  className="fill-gray-400"
+                  fontSize="10"
+                >
+                  {formatDate(item.date)}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/features/dashboard/hooks/useDashboardStats.ts
+++ b/frontend/src/features/dashboard/hooks/useDashboardStats.ts
@@ -1,0 +1,40 @@
+import useSWR from "swr";
+import {
+  fetchDashboardStats,
+  DASHBOARD_STATS_KEY,
+} from "../lib/api-client";
+import { defaultSWRConfig } from "@/lib/swr-config";
+import type { DashboardStats } from "../types/dashboard";
+
+/** Options for useDashboardStats hook */
+interface UseDashboardStatsOptions {
+  fallbackData?: DashboardStats;
+}
+
+/**
+ * SWR hook for fetching dashboard statistics
+ *
+ * Accepts optional fallbackData from SSR to avoid
+ * a loading flash on initial render.
+ */
+export function useDashboardStats(
+  options: UseDashboardStatsOptions = {},
+) {
+  const { data, error, isLoading, mutate } = useSWR<DashboardStats>(
+    DASHBOARD_STATS_KEY,
+    fetchDashboardStats,
+    {
+      ...defaultSWRConfig,
+      fallbackData: options.fallbackData,
+      revalidateIfStale: false,
+      revalidateOnMount: false,
+    },
+  );
+
+  return {
+    stats: data,
+    error,
+    isLoading,
+    refresh: mutate,
+  };
+}

--- a/frontend/src/features/dashboard/lib/api-client.ts
+++ b/frontend/src/features/dashboard/lib/api-client.ts
@@ -1,0 +1,18 @@
+import { httpClient } from "@/lib/api-client";
+import { API_ENDPOINTS } from "@/lib/constants";
+import type { DashboardStats } from "../types/dashboard";
+
+/**
+ * Fetch dashboard statistics for the current user
+ */
+export async function fetchDashboardStats():
+Promise<DashboardStats> {
+  return httpClient.get<DashboardStats>(
+    API_ENDPOINTS.DASHBOARD_STATS,
+  );
+}
+
+/**
+ * SWR key for dashboard stats
+ */
+export const DASHBOARD_STATS_KEY = API_ENDPOINTS.DASHBOARD_STATS;

--- a/frontend/src/features/dashboard/lib/server-fetcher.ts
+++ b/frontend/src/features/dashboard/lib/server-fetcher.ts
@@ -1,0 +1,34 @@
+import { cache } from "react";
+import { serverGet } from "@/lib/server/api-client";
+import type { DashboardStats } from "../types/dashboard";
+
+/** API response wrapper from Rails */
+interface ApiResponse<T> {
+  data: T;
+  status: { code: number; message: string };
+}
+
+/**
+ * Fetch dashboard stats on the server side
+ * Uses React.cache() for request-level deduplication
+ */
+const getCachedDashboardStats = cache(async () => {
+  return serverGet<ApiResponse<DashboardStats>>(
+    "/api/v1/dashboard/stats",
+  );
+});
+
+/**
+ * Fetch dashboard stats for SSR
+ * Returns null on failure so the page can still render
+ */
+export async function fetchDashboardData():
+Promise<DashboardStats | null> {
+  try {
+    const result = await getCachedDashboardStats();
+    return result?.data ?? null;
+  } catch (error) {
+    console.error("Failed to fetch dashboard stats:", error);
+    return null;
+  }
+}

--- a/frontend/src/features/dashboard/types/dashboard.ts
+++ b/frontend/src/features/dashboard/types/dashboard.ts
@@ -1,0 +1,47 @@
+/** Daily completion data for weekly trend chart */
+export interface DailyCompletion {
+  date: string;
+  count: number;
+}
+
+/** Category progress data */
+export interface CategoryProgress {
+  id: number;
+  name: string;
+  color: string;
+  total: number;
+  completed: number;
+  progress: number;
+}
+
+/** Completion statistics (today, this week, this month) */
+export interface CompletionStats {
+  today: number;
+  this_week: number;
+  this_month: number;
+  total: number;
+  total_completed: number;
+}
+
+/** Priority breakdown counts */
+export interface PriorityBreakdown {
+  low: number;
+  medium: number;
+  high: number;
+}
+
+/** Status breakdown counts */
+export interface StatusBreakdown {
+  pending: number;
+  in_progress: number;
+  completed: number;
+}
+
+/** Full dashboard stats response */
+export interface DashboardStats {
+  completion_stats: CompletionStats;
+  priority_breakdown: PriorityBreakdown;
+  status_breakdown: StatusBreakdown;
+  category_progress: CategoryProgress[];
+  weekly_trend: DailyCompletion[];
+}

--- a/frontend/src/features/todo/components/FilterBadges.tsx
+++ b/frontend/src/features/todo/components/FilterBadges.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { X } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -13,7 +14,12 @@ interface FilterBadgesProps {
   onClearAll: () => void;
 }
 
-export function FilterBadges({
+/**
+ * アクティブなフィルター条件をバッジ表示するコンポーネント
+ *
+ * memo化によりTodoリスト更新時の不要な再レンダリングを防止
+ */
+export const FilterBadges = memo(function FilterBadges({
   activeFilters,
   categories = [],
   tags = [],
@@ -144,4 +150,4 @@ export function FilterBadges({
       </Button>
     </div>
   );
-}
+});

--- a/frontend/src/features/todo/components/SearchBar.tsx
+++ b/frontend/src/features/todo/components/SearchBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, memo } from "react";
 import { Search, X } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -11,7 +11,12 @@ interface SearchBarProps {
   debounceDelay?: number;
 }
 
-export function SearchBar({
+/**
+ * デバウンス付き検索バーコンポーネント
+ *
+ * memo化によりフィルター変更時等の不要な再レンダリングを防止
+ */
+export const SearchBar = memo(function SearchBar({
   value,
   onChange,
   placeholder = "タスクを検索...",
@@ -64,4 +69,4 @@ export function SearchBar({
       )}
     </div>
   );
-}
+});

--- a/frontend/src/features/todo/components/TodoFilters.tsx
+++ b/frontend/src/features/todo/components/TodoFilters.tsx
@@ -1,3 +1,4 @@
+import { memo } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
@@ -15,7 +16,16 @@ interface TodoFiltersProps {
   };
 }
 
-export function TodoFilters({ currentFilter, onFilterChange, counts }: TodoFiltersProps) {
+/**
+ * Todoフィルターボタンコンポーネント
+ *
+ * memo化によりリスト更新時の不要な再レンダリングを防止
+ */
+export const TodoFilters = memo(function TodoFilters({
+  currentFilter,
+  onFilterChange,
+  counts,
+}: TodoFiltersProps) {
   const filters = [
     {
       key: TODO_FILTERS.ALL,
@@ -58,4 +68,4 @@ export function TodoFilters({ currentFilter, onFilterChange, counts }: TodoFilte
       ))}
     </div>
   );
-}
+});

--- a/frontend/src/features/todo/components/TodoListWithSearch.tsx
+++ b/frontend/src/features/todo/components/TodoListWithSearch.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useEffect } from "react";
 import dynamic from "next/dynamic";
 import { Plus } from "lucide-react";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
+import { useKeyboardShortcutContext } from "@/components/KeyboardShortcutProvider";
 
 import { useSearchParams } from "../hooks/useSearchParams";
 import { useTodoListData } from "../hooks/useTodoListData";
@@ -51,6 +52,12 @@ export function TodoListWithSearch({
 }: TodoListWithSearchProps = {}) {
   const [isCreateFormOpen, setIsCreateFormOpen] = useState(false);
   const [editingTodo, setEditingTodo] = useState<Todo | null>(null);
+
+  // Cmd+N でタスク作成フォームを開けるようにショートカット登録
+  const { registerCreateTodo } = useKeyboardShortcutContext();
+  useEffect(() => {
+    registerCreateTodo(() => setIsCreateFormOpen(true));
+  }, [registerCreateTodo]);
 
   // Search params management
   const {

--- a/frontend/src/features/todo/lib/api-client.ts
+++ b/frontend/src/features/todo/lib/api-client.ts
@@ -20,7 +20,16 @@ class TodoApiClient extends HttpClient {
     return this.get<Todo>(API_ENDPOINTS.TODO_BY_ID(id));
   }
 
-  async searchTodos(params: TodoSearchParams): Promise<TodoSearchResponse> {
+  /**
+   * Todo検索を実行する
+   *
+   * @param params - 検索パラメータ
+   * @param options - AbortSignal等のオプション
+   */
+  async searchTodos(
+    params: TodoSearchParams,
+    options?: { signal?: AbortSignal },
+  ): Promise<TodoSearchResponse> {
     // Build query string from params
     const queryParams = new URLSearchParams();
 
@@ -74,8 +83,13 @@ class TodoApiClient extends HttpClient {
     if (params.page) queryParams.append("page", String(params.page));
     if (params.per_page) queryParams.append("per_page", String(params.per_page));
 
-    const url = queryParams.toString() ? `${API_ENDPOINTS.TODOS_SEARCH}?${queryParams}` : API_ENDPOINTS.TODOS_SEARCH;
-    const response = await this.get<TodoSearchResponse>(url);
+    const url = queryParams.toString()
+      ? `${API_ENDPOINTS.TODOS_SEARCH}?${queryParams}`
+      : API_ENDPOINTS.TODOS_SEARCH;
+    const response = await this.get<TodoSearchResponse>(
+      url,
+      options,
+    );
     // dataプロパティが配列であることを保証
     if (response && typeof response === "object" && "data" in response) {
       return {

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -1,0 +1,98 @@
+"use client";
+
+import { useEffect, useCallback, useRef } from "react";
+
+/** ショートカット定義 */
+interface ShortcutDefinition {
+  /** ショートカットキー（小文字） */
+  key: string;
+  /** Cmd (mac) / Ctrl (win/linux) が必要か */
+  meta?: boolean;
+  /** Shift キーが必要か */
+  shift?: boolean;
+  /** 実行するハンドラー */
+  handler: () => void;
+  /** 入力フォーカス中でも有効にするか（デフォルト: false） */
+  activeInInput?: boolean;
+}
+
+/**
+ * テキスト入力要素にフォーカスがあるかを判定
+ */
+function isInputFocused(): boolean {
+  const el = document.activeElement;
+  if (!el) return false;
+  const tag = el.tagName.toLowerCase();
+  if (tag === "input" || tag === "textarea" || tag === "select") {
+    return true;
+  }
+  if (el instanceof HTMLElement && el.isContentEditable) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * グローバルキーボードショートカットを登録するhook
+ *
+ * input/textarea にフォーカスがあるときは
+ * meta付きショートカット以外を自動的に無効化する。
+ *
+ * @param shortcuts - ショートカット定義の配列
+ * @param enabled - ショートカット全体の有効/無効（デフォルト: true）
+ *
+ * @example
+ * ```tsx
+ * useKeyboardShortcuts([
+ *   { key: "k", meta: true, handler: openCommandPalette },
+ *   { key: "n", meta: true, handler: createNewTodo },
+ *   { key: "?", handler: openShortcutHelp },
+ * ]);
+ * ```
+ */
+export function useKeyboardShortcuts(
+  shortcuts: ShortcutDefinition[],
+  enabled: boolean = true,
+): void {
+  const shortcutsRef = useRef(shortcuts);
+  useEffect(() => {
+    shortcutsRef.current = shortcuts;
+  }, [shortcuts]);
+
+  const handleKeyDown = useCallback((e: KeyboardEvent) => {
+    if (!enabled || !e.key) return;
+
+    const isMeta = e.metaKey || e.ctrlKey;
+    const inputFocused = isInputFocused();
+
+    for (const shortcut of shortcutsRef.current) {
+      const keyMatch
+        = e.key.toLowerCase() === shortcut.key.toLowerCase();
+      const metaMatch = shortcut.meta ? isMeta : !isMeta;
+      const shiftMatch = shortcut.shift
+        ? e.shiftKey
+        : !e.shiftKey;
+
+      if (!keyMatch || !metaMatch || !shiftMatch) continue;
+
+      // 入力中は meta 付きショートカットまたは明示許可のみ有効
+      if (inputFocused && !shortcut.meta
+        && !shortcut.activeInInput) {
+        continue;
+      }
+
+      e.preventDefault();
+      e.stopPropagation();
+      shortcut.handler();
+      return;
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [handleKeyDown, enabled]);
+}

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -21,6 +21,12 @@ class HttpClient {
   // BFF経由で認証されるため、クライアント側での認証ヘッダー処理は不要
   // Cookieは自動的に送信される（credentials: "include"）
 
+  /**
+   * HTTP リクエストを実行する基底メソッド
+   *
+   * @param endpoint - APIエンドポイントパス
+   * @param options - fetch API のオプション（signal等を含む）
+   */
   private async request<T>(
     endpoint: string,
     options?: RequestInit,
@@ -85,16 +91,26 @@ class HttpClient {
       if (error instanceof ApiError) {
         throw error;
       }
+      // AbortController によるキャンセルはそのまま伝播
+      if (error instanceof DOMException && error.name === "AbortError") {
+        throw error;
+      }
       throw new ApiError("Network error occurred", 0);
     }
   }
 
-  async get<T>(endpoint: string): Promise<T> {
-    return this.request<T>(endpoint);
+  async get<T>(
+    endpoint: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<T> {
+    return this.request<T>(endpoint, options);
   }
 
-  async getList<T>(endpoint: string): Promise<T[]> {
-    const response = await this.request<T[]>(endpoint);
+  async getList<T>(
+    endpoint: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<T[]> {
+    const response = await this.request<T[]>(endpoint, options);
     return Array.isArray(response) ? response : [];
   }
 

--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -27,6 +27,8 @@ export const API_ENDPOINTS = {
   NOTE_REVISIONS: (noteId: number) => `/api/v1/notes/${noteId}/revisions`,
   NOTE_REVISION_RESTORE: (noteId: number, revisionId: number) =>
     `/api/v1/notes/${noteId}/revisions/${revisionId}/restore`,
+  // Dashboard endpoints
+  DASHBOARD_STATS: "/api/v1/dashboard/stats",
 } as const;
 
 export const TODO_FILTERS = {

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -67,3 +67,38 @@ export function debounce<T extends (...args: unknown[]) => unknown>(
 export function generateOptimisticId(): number {
   return Date.now() + Math.random();
 }
+
+/**
+ * macOS / iOS かどうかを判定する
+ *
+ * `navigator.userAgentData?.platform`（UA Client Hints）を優先し、
+ * 未サポートのブラウザでは `navigator.userAgent` にフォールバックする。
+ * SSR環境では `false` を返す。
+ */
+export function isMacOS(): boolean {
+  if (typeof navigator === "undefined") return false;
+
+  // UA Client Hints API（Chrome/Edge等）
+  const uaPlatform = (
+    navigator as Navigator & {
+      userAgentData?: { platform?: string };
+    }
+  ).userAgentData?.platform;
+  if (uaPlatform) {
+    return /mac/i.test(uaPlatform);
+  }
+
+  // フォールバック: userAgent 文字列
+  return /Macintosh|Mac OS X|iPhone|iPad|iPod/i.test(
+    navigator.userAgent,
+  );
+}
+
+/**
+ * OS に応じた修飾キーラベルを返す
+ *
+ * macOS / iOS の場合は "Cmd"、その他は "Ctrl"。
+ */
+export function getModKeyLabel(): string {
+  return isMacOS() ? "Cmd" : "Ctrl";
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -15,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {


### PR DESCRIPTION
## Summary

- **Backend search optimization**: Add pg_trgm GIN indexes for fast ILIKE partial-match search (language-independent, works for Japanese/English)
- **Backend caching**: Redis cache for categories/tags (5min TTL) with model-level cache invalidation callbacks
- **Backend security**: Rack::Attack rate limiting with JWT user ID extraction (BFF-compatible), secure MCP CORS origins and token config
- **Backend features**: ImageVariantJob for async image processing, Dashboard stats API with optimized CASE WHEN aggregation
- **Frontend performance**: Bundle size optimization (optimizePackageImports), AbortController for search request cancellation, memo-ized filter components
- **Frontend UX**: ErrorBoundary for feature-level error isolation, keyboard shortcuts (Cmd+K command palette, Cmd+N new todo, Cmd+/ help)
- **Frontend feature**: Dashboard page with stat cards, weekly completion chart, and category progress breakdown

## Commits (10)

| Scope | Commit | Description |
|-------|--------|-------------|
| docs | `a296824` | Update CLAUDE.md and AGENTS.md with test and CI info |
| backend | `b57f3a4` | Add pg_trgm indexes and ILIKE search optimization |
| backend | `a938f1b` | Add Redis caching for categories and tags |
| backend | `58937e9` | Add Rack::Attack rate limiting with JWT extraction |
| backend | `1752e0c` | Secure MCP CORS origins and token configuration |
| backend | `287049a` | Add ImageVariantJob for async image processing |
| backend | `66651ba` | Add dashboard stats API endpoint |
| frontend | `a140460` | Optimize bundle size and search performance |
| frontend | `f7cfd0f` | Add ErrorBoundary and keyboard shortcuts |
| frontend | `70ee942` | Add dashboard page with stats visualization |

## Test plan

- [x] Backend RSpec: 528 examples, 0 failures
- [x] Frontend Vitest: 4 files, 27 tests passed
- [x] Frontend ESLint: No errors
- [x] Frontend dev server: Next.js 16.1.3 (Turbopack) starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)